### PR TITLE
Fix grammar in ticklens description

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 - [React Native Lens UI Kit](https://github.com/lens-protocol/react-native-lens-ui-kit) - Lens UI Kit for React Native
 - [Subgraph](https://github.com/protofire/lens-protocol-subgraph) - The Graph subgraph.
 - [Talk-To-Lens](https://github.com/fabriguespe/Talk-To-Lens) - Plugin for querying lens database with natural language.
-- [ticklens](https://github.com/ArturVargas/ticklens.js) - A JavaScript SDK for create your own Ticket solution with Lens Protocol.
+- [ticklens](https://github.com/ArturVargas/ticklens.js) - A JavaScript SDK to create your own Ticket solution with Lens Protocol.
 - [use-lens](https://github.com/use-lens/use-lens) - Simplify usage of Lens API with graphql-codegen.
 - [worldcoin-on-lens](https://github.com/AdamSchinzel/worldcoin-on-lens) - Find out which people have World ID verified on Lens.
 


### PR DESCRIPTION
## Summary
- Fixed grammatical error in the ticklens library description
- Changed "A JavaScript SDK for create your own Ticket solution" to "A JavaScript SDK to create your own Ticket solution"

## Details
The original description used "for create" which is grammatically incorrect. The proper form should use "to create" (infinitive form).