### PR TITLE
Fix typo in Dune dashboard description

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@
 
 ## Stats & Dashboards
 - [Dune - Lens](https://dune.com/niftytable/Lens) - Lens dashboard in Dune.
-- [Dune - Lens and Hey](https://dune.com/gm365/lens) - Lens and Hey dashboard in Lens.
+- [Dune - Lens and Hey](https://dune.com/gm365/lens) - Lens and Hey dashboard in Dune.
 - [Lens Analytics by addresszero](https://github.com/addresszero/lensanalytics) - Lens Protocol Explorer 📈🌿
 - [Lens Analytics by chiragbadhe](https://github.com/chiragbadhe/lensanalytics) - Metrics On Lens Ecosystem.
 - [Leaderboards WithLens](https://github.com/m1guelpf/lens-leaderboard) - Most followed, active, collected shared profiles.


### PR DESCRIPTION
## Summary
- Fixed typo in the Dune - Lens and Hey dashboard description
- Changed "Lens and Hey dashboard in Lens" to "Lens and Hey dashboard in Dune"

## Details
The description incorrectly stated the dashboard was "in Lens" when it should say "in Dune" since it's a Dune Analytics dashboard.