### PR TITLE
Add missing periods to descriptions per contribution guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@
 - [Greenhouse](https://github.com/dsimmons/greenhouse) - Grow and spread your web3 roots.
 - [Lens Protocol Explorer](https://lenscan.io/) - Explore the interesting events happening on the Lens Protocol.
 - [lens.js](https://github.com/suhailkakar/lens.js) - JavaScript SDK.
-- [lens-protocol/sdk-gated](https://www.npmjs.com/package/@lens-protocol/sdk-gated) - Gated encrypting and decrypting publication metadata compatible with the Lens API
+- [lens-protocol/sdk-gated](https://www.npmjs.com/package/@lens-protocol/sdk-gated) - Gated encrypting and decrypting publication metadata compatible with the Lens API.
 - [lens-token-gated-posts](https://github.com/jaencarrodine/lens-token-gated-posts) - Token gated Lens posts example.
 - [lens-use](https://github.com/memester-xyz/lens-use) - React hooks for Lens.
-- [LensPy](https://github.com/TobiasLoader/LensPy) - Python library for the Lens Protocol
+- [LensPy](https://github.com/TobiasLoader/LensPy) - Python library for the Lens Protocol.
 - [react-lens-share-button](https://www.npmjs.com/package/@infinity-keys/react-lens-share-button) - A customizable, React button component for sharing to Lens.
-- [React Native Lens UI Kit](https://github.com/lens-protocol/react-native-lens-ui-kit) - Lens UI Kit for React Native
+- [React Native Lens UI Kit](https://github.com/lens-protocol/react-native-lens-ui-kit) - Lens UI Kit for React Native.
 - [Subgraph](https://github.com/protofire/lens-protocol-subgraph) - The Graph subgraph.
 - [Talk-To-Lens](https://github.com/fabriguespe/Talk-To-Lens) - Plugin for querying lens database with natural language.
 - [ticklens](https://github.com/ArturVargas/ticklens.js) - A JavaScript SDK for create your own Ticket solution with Lens Protocol.
@@ -55,7 +55,7 @@
 ### Starter Kits
 - [daoleno/lenskit](https://github.com/daoleno/lenskit) - Starter kit by daoleno.
 - [thirdweb-example/lens](https://github.com/thirdweb-example/lens) - Starter kit for using Lens Protocol with the thirdweb SDK.
-- [lens-xmtp-push-expo-typescript-template](https://github.com/desoul-labs/lens-xmtp-push-expo-typescript-template) - An Expo template for building Web3 social apps integrated with Lens Protocol, XMTP, and Push Protocol(EPNS)
+- [lens-xmtp-push-expo-typescript-template](https://github.com/desoul-labs/lens-xmtp-push-expo-typescript-template) - An Expo template for building Web3 social apps integrated with Lens Protocol, XMTP, and Push Protocol (EPNS).
 
 ### Modules
 - [Lens Modules](https://github.com/lens-protocol/modules) - Repository for adding collect, follow and reference modules.
@@ -65,10 +65,10 @@
 
 > Momoka refers to an Optimistic L3 - a hybrid by taking best from both - Optimistic Rollups and L3 technologies
 
-- [Momoka](https://github.com/lens-protocol/momoka) - Open source code showing how you can verify the DA claims are true
+- [Momoka](https://github.com/lens-protocol/momoka) - Open source code showing how you can verify the DA claims are true.
   - [Node client](https://github.com/lens-protocol/momoka/tree/master/momoka-node)
   - [Rust client](https://github.com/lens-protocol/momoka/tree/master/momoka-rs)
-- [Momoka Explorer](https://github.com/lens-protocol/momoka-explorer) - DA explorer for Lens
+- [Momoka Explorer](https://github.com/lens-protocol/momoka-explorer) - DA explorer for Lens.
 - [Momoka Explorer Web](https://momoka.lens.xyz/)
 
 ## Learn
@@ -89,7 +89,7 @@
 
 - [API examples](https://github.com/lens-protocol/api-examples) - Official API examples.
 - [Frontend examples](https://github.com/dabit3/lens-protocol-frontend) - Example of a basic front end.
-- [Lens Blog](https://github.com/PatrickAlphaC/lens-blog) - A minimal example of using Lens Protocol to build a blog
+- [Lens Blog](https://github.com/PatrickAlphaC/lens-blog) - A minimal example of using Lens Protocol to build a blog.
 - [lens-create-publication-example](https://github.com/dabit3/lens-create-publication-example) - An example project showing how to create a publication using withSig and typed data.
 - [lens-gated-publications](https://github.com/dabit3/lens-gated-publications) - Example application implementing gated Lens posts, encryption, and decryption.
 
@@ -99,7 +99,7 @@
 
 > Add `lensprotocol` or `lens-protocol` tag to the repository for easy discoverability
 
-- [Chainblog](https://github.com/jarrodwatts/chainblog) - The decentralized blogging platform
+- [Chainblog](https://github.com/jarrodwatts/chainblog) - The decentralized blogging platform.
 - [Clipto](https://github.com/Clipto-Platform/clipto-frontend) - Personalized videos from your favorite Creators.
 - [Cultivator](https://github.com/maui-r/cultivator) - Explore the Lens Protocol Social Graph.
 - [Encrypted Messaging for Lens](https://github.com/GrgW/lens-encrypted-messaging-redacted) - Encrypt messages for a Lens Profile or their Followers.
@@ -120,7 +120,7 @@
 - [Reroot](https://github.com/stuntzii/Reroot) - A browser extension for Twitter that lets you also post to Lens.
 - [SendACoin](https://github.com/SendACoin/sendacoin.to) - Share your Lens profile, collect Payments, tips.
 - [Sepana](https://github.com/sepana-io/lens-search-frontend) - Search and explore its posts, people, and connections.
-- [twitter-clone-LensProtocol](https://github.com/Merdi-kim/twitter-clone-LensProtocol) - Decentralized twitter clone built with Lens Protocol and Web3.storage
+- [twitter-clone-LensProtocol](https://github.com/Merdi-kim/twitter-clone-LensProtocol) - Decentralized Twitter clone built with Lens Protocol and Web3.storage.
 - [Wired](https://github.com/wired-labs/wired) - An open and decentralized web-based metaverse platform.
 - [World ID Lens](https://github.com/worldcoin/world-id-lens) - Human verification for Lens Protocol with World ID.
 
@@ -137,7 +137,7 @@
 - [Meetvers](https://app.meetvers.io/) - Find friends with similar Web3 footprint.
 - [memester](https://memester.xyz/) - The NFT Meme Platform. Create memes and turn them into NFTs. Participate in meme competitions and win prizes.
 - [Phaver](https://phaver.com/) - Share-to-earn decentralized social platform.
-- [Onboard](https://twitter.com/Onboard_HQ) - The social media you deserve
+- [Onboard](https://twitter.com/Onboard_HQ) - The social media you deserve.
 - [Orb](https://orb.ac/) - Best place to network in web3.
 - [Share](https://theshr.xyz/) - Publish, Read, Connect and Collect the Best Books of Your Favorite Authors.
 - [Superfun](https://lens.superfun.social/) - A social app for Meme artists to get rewarded for their super fun content.


### PR DESCRIPTION
## Summary
Added missing periods at the end of descriptions to follow the contribution guidelines which state: "Start the description with a capital and end with a full stop/period."

## Changes
Added periods to the following entries:
- lens-protocol/sdk-gated
- LensPy
- React Native Lens UI Kit
- lens-xmtp-push-expo-typescript-template (also added space before parentheses)
- Momoka
- Momoka Explorer
- Lens Blog
- Chainblog
- twitter-clone-LensProtocol (also capitalized Twitter)
- Onboard