### PR TITLE
Use HTTPS for makeapullrequest.com link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
     <a href="https://github.com/0xJuancito/awesome-lens-protocol/graphs/contributors">
       <img alt="GitHub contributors" src="https://img.shields.io/github/contributors/0xJuancito/awesome-lens-protocol">
     </a>    
-    <a href="http://makeapullrequest.com">
+    <a href="https://makeapullrequest.com">
       <img alt="pull requests welcome badge" src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat">
     </a>
   </p>


### PR DESCRIPTION
## Summary
Updated the makeapullrequest.com link to use HTTPS instead of HTTP for improved security.

## Changes
- Changed `http://makeapullrequest.com` to `https://makeapullrequest.com`

Using HTTPS ensures secure connections and follows modern web security best practices.